### PR TITLE
Add example secret ID for certmanager.

### DIFF
--- a/docs/sample-configs/static-config.yml
+++ b/docs/sample-configs/static-config.yml
@@ -1,5 +1,9 @@
 base:
   acme:
+    # The instance role must have access to update the Route 53 zone and
+    # read/write the secret in AWS Secrets Manager. The zone must be public, so
+    # that Let's Encrypt can see the challenge responses.
+    aws_secret_id:          cloud_gate/x509
     challenge_type:         dns-01
     domain_names:           ["cloud-gate.example.com"]
     route53_hosted_zone_id: "Z13D344AAABBB"


### PR DESCRIPTION
This should not be merged until Cloud-Foundations/golib#14 has been merged.